### PR TITLE
Prepping for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ categories = ["embedded", "no-std"]
 name = "enc424j600"
 description = "Embbeded Rust Ethernet driver for ENC424J600 Ethernet controller with SPI interface"
 authors = ["Harry Ho <hh@m-labs.hk>", "Dip Cheung <dc@m-labs.hk>"]
-version = "0.2.0"
+version = "0.3.0"
 keywords = ["ethernet", "eth", "enc424j600", "stm32", "stm32f4xx"]
-repository = "https://git.m-labs.hk/M-Labs/ENC424J600"
+repository = "https://github.com/quartiq/enc424j600"
 edition = "2018"
 license = "BSD-2-Clause"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Embbeded Rust Ethernet driver for ENC424J600 Ethernet controller 
 authors = ["Harry Ho <hh@m-labs.hk>", "Dip Cheung <dc@m-labs.hk>"]
 version = "0.3.0"
 keywords = ["ethernet", "eth", "enc424j600", "stm32", "stm32f4xx"]
-repository = "https://github.com/quartiq/enc424j600"
+repository = "https://git.m-labs.hk/M-Labs/ENC424J600"
 edition = "2018"
 license = "BSD-2-Clause"
 


### PR DESCRIPTION
Prepping for a 0.3.0 release

I'm intentionally trying to not touch any of the actual code because I cannot test the ENC424J600 driver on hardware.

This PR just updates the pointers for release.